### PR TITLE
Turn logic

### DIFF
--- a/client/actions/move.js
+++ b/client/actions/move.js
@@ -1,4 +1,4 @@
-import socket, {takeTurn} from '../socket'
+import socket from '../socket'
 import {unitSprites} from '../renderers/units'
 import {SCALE, getOffset, gameboard, gameState} from '../index'
 import {BoardContainer} from '../renderers/board'
@@ -22,9 +22,6 @@ export function handleMove(unitSprite, newTile) {
     let coordinates = unitSprite.data.currentTile.coordinates
     let name = unitSprite.data.name
     let unit = {coordinates, name}
-    // updateUnits(unit)
-    takeTurn(gameState)
-    console.log('update view success')
     //sends move to socket server
     console.log('emitting move to socket server', unit)
     //emit only to people in room
@@ -64,7 +61,6 @@ export function handleAttack(attacker, defender) {
     let health = defender.health
     let unit = {name, health}
 
-    updateUnitsHealth(unit)
     attacker.toggleSelected(false)
 
     socket.emit('updateUnits', unit, gameState)

--- a/client/index.js
+++ b/client/index.js
@@ -163,6 +163,7 @@ export function renderGame(name) {
   return function(roomObj) {
     //Global gameState stored locally
     //socket object is owner of currentPlayers
+    gameState.me = playerName
     gameState.currentPlayers = roomObj.currentPlayers
     gameState.currentTurn =
       gameState.currentTurn === 'player1' ? 'player2' : 'player1'
@@ -173,21 +174,26 @@ export function renderGame(name) {
     // once you select a unit, you can click on any enemy unit within range
 
     // console.log('BoardContainer', BoardContainer)
-    // console.log('unitSprites', unitSprites)
+    console.log('unitSprites before update', unitSprites)
 
-    // unitSprites.map(unitSprite => {
-    //   BoardContainer.removeChild(unitSprite)
+    unitSprites.forEach(unitSprite => {
+      BoardContainer.removeChild(unitSprite)
 
-    //   if (gameState.currentTurn === playerName) {
-    //     unitSprite.interactive = true
-    //     unitSprite.buttonMode = true
-    //   } else {
-    //     unitSprite.interactive = false
-    //     unitSprite.buttonMode = false
-    //   }
+      if (
+        gameState.currentTurn === playerName &&
+        gameState.currentTurn === unitSprite.data.playerName
+      ) {
+        unitSprite.interactive = true
+        unitSprite.buttonMode = true
+      } else {
+        unitSprite.interactive = false
+        unitSprite.buttonMode = false
+      }
 
-    //   BoardContainer.addChild(unitSprite)
-    // })
+      BoardContainer.addChild(unitSprite)
+    })
+
+    console.log('unitSprites after update', unitSprites)
 
     // if (gameState.currentTurn === playerName) {
     //   console.log('enabling interaction with troops')

--- a/client/renderers/units.js
+++ b/client/renderers/units.js
@@ -1,5 +1,11 @@
 import * as PIXI from 'pixi.js'
-import {SCALE, GameContainer, updateSelectedUnit, getOffset} from '../index'
+import {
+  SCALE,
+  GameContainer,
+  updateSelectedUnit,
+  getOffset,
+  gameState
+} from '../index'
 import {BoardContainer} from './board'
 import {selectedUnit} from '../index'
 import {handleAttack, updateUnitsHealth} from '../actions/move'
@@ -12,6 +18,39 @@ const unitTextures = [rifleUnitRed, rifleUnitBlue]
 
 //stores rendered unitSprites added to gameboard
 export let unitSprites = []
+
+//enables interactive and buttonMode on all unitSprites including enemies
+function makeClickable() {
+  unitSprites.forEach(unitSprite => {
+    BoardContainer.removeChild(unitSprite)
+    unitSprite.interactive = true
+    unitSprite.buttonMode = true
+    BoardContainer.addChild(unitSprite)
+  })
+}
+
+//player can click their own units
+//player cannot click their enemy's units
+//enemy cannot click any units
+function disableEnemyInteraction() {
+  unitSprites.forEach(unitSprite => {
+    BoardContainer.removeChild(unitSprite)
+    if (
+      gameState.currentTurn === gameState.me &&
+      gameState.currentTurn === unitSprite.data.playerName
+    ) {
+      console.log(unitSprite, 'set to true')
+      unitSprite.interactive = true
+      unitSprite.buttonMode = true
+    } else {
+      console.log(unitSprite, 'set to false')
+      unitSprite.interactive = false
+      unitSprite.buttonMode = false
+    }
+
+    BoardContainer.addChild(unitSprite)
+  })
+}
 
 /*
 * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -59,12 +98,16 @@ export function renderUnits(unitArr) {
       if (!selectedUnit.data) {
         console.log('new unit selected!', unitSprite.data)
         updateSelectedUnit(unitSprite)
+        //make enemy units clickable
+        makeClickable()
       } else {
         //if you click on unit that's already selected, unselect it
         // eslint-disable-next-line no-lonely-if
         if (unitSprite === selectedUnit) {
           console.log('unselected unit: ', unitSprite.data)
           updateSelectedUnit({})
+          //disable enemy interaction
+          disableEnemyInteraction()
         } else if (
           unitSprite.data.playerName === selectedUnit.data.playerName
         ) {
@@ -75,6 +118,7 @@ export function renderUnits(unitArr) {
           //if you click enemy unit, attempt attack
           handleAttack(selectedUnit.data, unitSprite.data)
           updateSelectedUnit({})
+          disableEnemyInteraction()
         }
       }
       // console.log('selectedUnit isSelected?:', unitSprite.data.isSelected)


### PR DESCRIPTION
Fixed a couple bugs that were preventing basic turn logic from working:
1. We were calling takeTurn() on both the handleAttack and in the broadcast listener.
2. We were mapping over the unitSprites in takeTurn() so the sprites .interactive props weren’t being updated.  I eventually realized we can just use a forEach method to mutate the individual indexes (we cannot reassign values in map because it’s an exported object.

The turn logic now has full functionality!
A player can click their own units
A player cannot click their enemy’s units until they click one of their own.
A player cannot click their enemy’s units after they select and deselect one of their own units or take an invalid shot at an enemy out of range
A enemy cannot click any units during the opposing players turn
